### PR TITLE
[FIX] SQL Level 5, variable should not be inside string single-quotes

### DIFF
--- a/SQL/sql5.php
+++ b/SQL/sql5.php
@@ -47,7 +47,7 @@
 			exit;
 		}
 
-		$query = "SELECT bookname,authorname FROM books WHERE number =".'$number'; 
+		$query = "SELECT bookname,authorname FROM books WHERE number =".$number;
 		$result = mysqli_query($conn,$query);
 
 		if (!$result) { //Check result


### PR DESCRIPTION
Line 50 
`$query = "SELECT bookname,authorname FROM books WHERE number =".'$number';` 

in `sql5.php` will never work, as `'$number'` is a string.

Asuming this was an error, this PR fixes this issue.